### PR TITLE
Allow pulling additional metrics from bandwidth search

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -458,6 +458,9 @@ class BaseClassifier(_BaseModel, ClassifierMixin):
         complexity (smaller bandwidths)
     bic_ : float
         Bayesian information criterion
+    prediction_rate_ : float
+        Proportion of models that are fitted, where the rest is skipped due to not
+        fulfiilling ``min_proportion``.
     """
 
     def __init__(
@@ -610,6 +613,8 @@ class BaseClassifier(_BaseModel, ClassifierMixin):
         # global GW accuracy
         nan_mask = self.proba_[col].isna()
         self.pred_ = self.proba_[col][~nan_mask] > 0.5
+
+        self.prediction_rate_ = 1 - (nan_mask.sum() / nan_mask.shape[0])
 
         if self.fit_global_model:
             if self.verbose:

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -97,7 +97,7 @@ class _BaseModel(BaseEstimator):
         graph: graph.Graph = None,
         n_jobs: int = -1,
         fit_global_model: bool = True,
-        measure_performance: bool = True,
+        measure_performance: bool | list = True,
         strict: bool | None = False,
         keep_models: bool | str | Path = False,
         temp_folder: str | None = None,
@@ -392,9 +392,10 @@ class BaseClassifier(_BaseModel, ClassifierMixin):
     fit_global_model : bool, optional
         Determines if the global baseline model shall be fitted alognside
         the geographically weighted, by default True
-    measure_performance : bool, optional
+    measure_performance : bool | str, optional
         Calculate performance metrics for the model. If True, measures accurace score,
-        precision, recall, balanced accuracy, and F1 scores. By default True
+        precision, recall, balanced accuracy, and F1 scores. A subset of these can
+        be specified by passing a list of strings. By default True
     strict : bool | None, optional
         Do not fit any models if at least one neighborhood has invariant ``y``,
         by default False. None is treated as False but provides a warning if there are
@@ -616,26 +617,54 @@ class BaseClassifier(_BaseModel, ClassifierMixin):
             self._fit_global_model(X, y)
 
         if self.measure_performance:
+            if self.measure_performance is True:
+                metrics_to_measure = [
+                    "accuracy",
+                    "precision",
+                    "recall",
+                    "balanced_accuracy",
+                    "f1_macro",
+                    "f1_micro",
+                    "f1_weighted",
+                ]
+            else:
+                metrics_to_measure = self.measure_performance
             if self.verbose:
                 print(f"{(time() - self._start):.2f}s: Measuring focal performance")
             masked_y = y[~nan_mask]
-            self.score_ = metrics.accuracy_score(masked_y, self.pred_)
-            self.precision_ = metrics.precision_score(
-                masked_y, self.pred_, zero_division=0
-            )
-            self.recall_ = metrics.recall_score(masked_y, self.pred_, zero_division=0)
-            self.balanced_accuracy_ = metrics.balanced_accuracy_score(
-                masked_y, self.pred_
-            )
-            self.f1_macro_ = metrics.f1_score(
-                masked_y, self.pred_, average="macro", zero_division=0
-            )
-            self.f1_micro_ = metrics.f1_score(
-                masked_y, self.pred_, average="micro", zero_division=0
-            )
-            self.f1_weighted_ = metrics.f1_score(
-                masked_y, self.pred_, average="weighted", zero_division=0
-            )
+
+            if "accuracy" in metrics_to_measure:
+                self.score_ = metrics.accuracy_score(masked_y, self.pred_)
+
+            if "precision" in metrics_to_measure:
+                self.precision_ = metrics.precision_score(
+                    masked_y, self.pred_, zero_division=0
+                )
+
+            if "recall" in metrics_to_measure:
+                self.recall_ = metrics.recall_score(
+                    masked_y, self.pred_, zero_division=0
+                )
+
+            if "balanced_accuracy" in metrics_to_measure:
+                self.balanced_accuracy_ = metrics.balanced_accuracy_score(
+                    masked_y, self.pred_
+                )
+
+            if "f1_macro" in metrics_to_measure:
+                self.f1_macro_ = metrics.f1_score(
+                    masked_y, self.pred_, average="macro", zero_division=0
+                )
+
+            if "f1_micro" in metrics_to_measure:
+                self.f1_micro_ = metrics.f1_score(
+                    masked_y, self.pred_, average="micro", zero_division=0
+                )
+
+            if "f1_weighted" in metrics_to_measure:
+                self.f1_weighted_ = metrics.f1_score(
+                    masked_y, self.pred_, average="weighted", zero_division=0
+                )
 
         # Compute global log likelihood and information criteria
         if self.verbose:

--- a/gwlearn/search.py
+++ b/gwlearn/search.py
@@ -135,8 +135,10 @@ class BandwidthSearch:
             **self._model_kwargs,
         ).fit(X=X, y=y, geometry=geometry)
 
+        met = [] if self.metrics is None else self.metrics
+
         additional_metrics = []
-        for m in self.metrics:
+        for m in met:
             if m == "accuracy":
                 m = "score"
             additional_metrics.append(getattr(gwm, m + "_"))

--- a/gwlearn/search.py
+++ b/gwlearn/search.py
@@ -43,7 +43,7 @@ class BandwidthSearch:
     metrics : list, optional
         List of additional metrics beyond ``criterion`` to be reported. Has to be
         a metric supported by ``model``, passable to ``measure_performance`` argument
-        of model's intialization.
+        of model's intialization or 'prediction_rate'.
     min_bandwidth : int | float | None, optional
         Minimum bandwidth to consider, by default None
     max_bandwidth : int | float | None, optional

--- a/gwlearn/tests/test_search.py
+++ b/gwlearn/tests/test_search.py
@@ -315,7 +315,7 @@ def test_bandwidth_search_verbosity(sample_data):  # noqa: F811
     # Check that bandwidth and score information is printed
     assert "Bandwidth: 100000" in output
     assert "Bandwidth: 200000" in output
-    assert "score:" in output
+    assert "aicc:" in output
 
     # Check with verbose=False (should not produce output)
     search_quiet = BandwidthSearch(


### PR DESCRIPTION
Given classification models that leave out some local model due to class imbalance cannot simply use AICc to determine the optimal bandwidth (as the number of observations differ), trying to enable more customised ways of determining what is the best. This allows pulling additional data, e.g. perf metrics, even though they're not optimal, and prediction rate, capturing the amount of local models that are left out.

Still needs tests and exposure outside of the BaseClassifier. 