### PR TITLE
CI: replace deprecated macos-13 with macos-15-intel

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
         ]
         include:
           - environment-file: py313_latest
-            os: macos-13  # Intel
+            os: macos-15-intel
           - environment-file: py313_latest
             os: macos-latest  # Apple Silicon
           - environment-file: py313_latest


### PR DESCRIPTION
@jgaboardi this will need to happen across the federation. See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/