### PR TITLE
clean up `n_jobs` warning

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 from collections.abc import Callable, Hashable
 from pathlib import Path
@@ -250,9 +251,19 @@ class _BaseModel(BaseEstimator):
         if self._model_type == "random_forest":
             self._model_kwargs["oob_score"] = True
         # fit global model as a baseline
-        self.global_model = self.model(**self._model_kwargs)
+        if "n_jobs" in inspect.signature(self.model).parameters:
+            self.global_model = self.model(n_jobs=self.n_jobs, **self._model_kwargs)
+        else:
+            self.global_model = self.model(**self._model_kwargs)
 
-        self.global_model.fit(X=X, y=y)
+        # see gh#44 - remove filter once oldest sklearn is 1.10
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="'n_jobs' has no effect since 1.8 and will be removed in 1.10.",
+                category=FutureWarning,
+            )
+            self.global_model.fit(X=X, y=y)
 
     def _store_model(self, local_model, name: Hashable):
         """Store or serialize local model"""


### PR DESCRIPTION
This PR addresses the `FutureWarning` being thrown when [passing `n_jobs` into `model`](https://github.com/pysal/gwlearn/blob/2f5c5cb21c4ad689d259e19380c20e6a6d4bdd3c/gwlearn/base.py#L255)

```
/home/runner/micromamba/envs/py314-latest/lib/python3.14/site-packages/sklearn/linear_model/_logistic.py:1184: FutureWarning: 'n_jobs' has no effect since 1.8 and will be removed in 1.10. You provided 'n_jobs=-1', please leave it unspecified.
    warnings.warn(msg, category=FutureWarning)
```

* 4,769 warnings [before](https://github.com/pysal/gwlearn/actions/runs/20586808705/job/59124608137#step:7:272)
* 4,748 warnings [after](https://github.com/pysal/gwlearn/actions/runs/20587471100/job/59126345832#step:7:261) 