### PR TITLE
DOC: automatically build docs for stable (on version) and latest (on push)

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -4,6 +4,8 @@ name: Build Docs
 on:
   push:
     branches: [main]
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -17,7 +19,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ["ubuntu-latest"]
         environment-file: [ci/py313_latest.yaml]
         experimental: [false]
     defaults:
@@ -34,10 +36,10 @@ jobs:
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: ${{ matrix.environment-file }}
-          micromamba-version: 'latest'
+          micromamba-version: "latest"
 
       - name: install package
-        run: pip install .
+        run: pip install . --no-deps
 
       - name: make docs
         run: cd docs; make html
@@ -48,3 +50,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html/
           keep_files: false
+          destination_dir: ${{ github.ref_type == 'tag' && 'stable' || 'latest' }}

--- a/ci/py313_latest.yaml
+++ b/ci/py313_latest.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytest-xdist
   - pytest-doctestplus
   # docs
+  - pandarm
   - ipykernel
   - myst-nb
   - sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -142,6 +142,12 @@ html_theme_options = {
             },
         },
     ],
+    "version_dropdown": True,
+    "version_info": [
+        {"version": "stable", "title": "stable", "aliases": []},
+        {"version": "latest", "title": "latest", "aliases": []},
+    ],
 }
-nb_execution_mode = "off"
+nb_execution_mode = "cache"
+nb_execution_timeout = -1
 autodoc_typehints = "none"


### PR DESCRIPTION
cc @jGaboardi - experimental so far but might enable us to keep the docs of older versions around as readthedocs can. What I also like here is that the action actually runs on each commit to main so we can catch issues when they happen, not when we try to cut a release.