### PR TITLE
GHA: ignore pre-commit-ci[bot] in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - ignore-for-release
     authors:
       - dependabot
+      - pre-commit-ci[bot]
   categories:
     - title: Bug Fixes
       labels:


### PR DESCRIPTION
Likely should be done in lib and other packages as well.