### PR TITLE
Enable internal metadata routing for geometry

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -709,7 +709,10 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         self._empty_feature_imp = None
 
     def fit(
-        self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None,**kwargs
+        self,
+        X: pd.DataFrame,
+        y: pd.Series, geometry: gpd.GeoSeries | None = None,
+        **_fit_params
     ) -> "BaseClassifier":
         """Fit geographically weighted local classification models.
 
@@ -1442,7 +1445,11 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         self.random_state = random_state
 
     def fit(
-        self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None,**kwargs
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        geometry: gpd.GeoSeries | None = None,
+        **_fit_params
     ) -> "BaseRegressor":
         """Fit geographically weighted local regression models.
 

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -743,8 +743,8 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         Notes
         -----
         The neighborhood definition comes from either ``self.graph`` or from
-        ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``).
-        """
+        ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``)."""
+    
     if _routing_enabled():
                 self.set_fit_request(geometry=True)
 

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -13,6 +13,7 @@ from libpysal import graph
 from scipy.spatial import KDTree
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.model_selection import train_test_split
+from sklearn.utils.metadata_routing import _routing_enabled
 
 __all__ = ["BaseClassifier", "BaseRegressor"]
 
@@ -744,6 +745,10 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         The neighborhood definition comes from either ``self.graph`` or from
         ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``).
         """
+            if _routing_enabled():
+                self.set_fit_request(geometry=True)
+
+        
         self._start = time()
 
         self.geometry = geometry
@@ -1483,6 +1488,10 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         """
         if self.graph is None:
             self._validate_geometry(geometry)
+        if _routing_enabled():
+            self.set_fit_request(geometry=True)
+
+        self._start = time()
 
         self.geometry = geometry
 

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -708,14 +708,13 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         self.leave_out = leave_out
         self._empty_score_data = None
         self._empty_feature_imp = None
-
-  def fit(
-    self,
-    X: pd.DataFrame,
-    y: pd.Series,
-    geometry: gpd.GeoSeries | None = None,
-    **_fit_params,
-) -> "BaseClassifier":
+    def fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        geometry: gpd.GeoSeries | None = None,
+        **_fit_params,
+    ) -> "BaseClassifier":
     """Fit geographically weighted local classification models.
 
     This fits one local model per focal observation (subject to local invariance
@@ -746,19 +745,13 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
     The neighborhood definition comes from either ``self.graph`` or from
     ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``).
     """
-
-    if self.graph is None:
-        self._validate_geometry(geometry)
-
-    if _routing_enabled():
-        self.set_fit_request(geometry=True)
-
-    self._start = time()
-    self.geometry = geometry
-
-    
-   
-        def _is_binary(series: pd.Series) -> bool:
+        if self.graph is None:
+            self._validate_geometry(geometry)
+        if _routing_enabled():
+            self.set_fit_request(geometry=True)
+        self._start = time()
+        self.geometry = geometry
+    def _is_binary(series: pd.Series) -> bool:
             """Check if a pandas Series encodes a binary variable (bool or 0/1)."""
             unique_values = set(np.unique(series))
 

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -709,48 +709,55 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         self._empty_score_data = None
         self._empty_feature_imp = None
 
-    def fit(
-        self,
-        X: pd.DataFrame,
-        y: pd.Series, geometry: gpd.GeoSeries | None = None,
-        **_fit_params
-    ) -> "BaseClassifier":
-        """Fit geographically weighted local classification models.
+  def fit(
+    self,
+    X: pd.DataFrame,
+    y: pd.Series,
+    geometry: gpd.GeoSeries | None = None,
+    **_fit_params,
+) -> "BaseClassifier":
+    """Fit geographically weighted local classification models.
 
-        This fits one local model per focal observation (subject to local invariance
-        checks and ``min_proportion``) and stores focal predictions.
+    This fits one local model per focal observation (subject to local invariance
+    checks and ``min_proportion``) and stores focal predictions.
 
-        Parameters
-        ----------
-        X : pandas.DataFrame
-            Feature matrix.
-        y : pandas.Series
-            Binary target encoded as boolean or ``{0, 1}``.
-        geometry : geopandas.GeoSeries | None
-            Geographic location of the observations in the sample. Used to determine the
-            spatial interaction weight based on specification by ``bandwidth``,
-            ``fixed``, ``kernel``, and ``include_focal`` keywords.  If `None`,
-            a precomputed ``graph`` needs to be specified. To allow prediction,
-            it is required to specify ``geometry``. If both ``graph`` and ``geometry``
-            are specified, ``graph`` is used at the fit time, while ``geometry`` is
-            used for prediction.
+    Parameters
+    ----------
+    X : pandas.DataFrame
+        Feature matrix.
+    y : pandas.Series
+        Binary target encoded as boolean or ``{0, 1}``.
+    geometry : geopandas.GeoSeries | None
+        Geographic location of the observations in the sample. Used to determine the
+        spatial interaction weight based on specification by ``bandwidth``,
+        ``fixed``, ``kernel``, and ``include_focal`` keywords.  If `None`,
+        a precomputed ``graph`` needs to be specified. To allow prediction,
+        it is required to specify ``geometry``. If both ``graph`` and ``geometry``
+        are specified, ``graph`` is used at the fit time, while ``geometry`` is
+        used for prediction.
 
-        Returns
-        -------
-        self
-            Fitted estimator.
+    Returns
+    -------
+    self
+        Fitted estimator.
 
-        Notes
-        -----
-        The neighborhood definition comes from either ``self.graph`` or from
-        ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``)."""
-    
+    Notes
+    -----
+    The neighborhood definition comes from either ``self.graph`` or from
+    ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``).
+    """
+
+    if self.graph is None:
+        self._validate_geometry(geometry)
+
     if _routing_enabled():
-                self.set_fit_request(geometry=True)
+        self.set_fit_request(geometry=True)
 
-        self._start = time()
-        self.geometry = geometry
+    self._start = time()
+    self.geometry = geometry
 
+    
+   
         def _is_binary(series: pd.Series) -> bool:
             """Check if a pandas Series encodes a binary variable (bool or 0/1)."""
             unique_values = set(np.unique(series))

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -745,12 +745,10 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         The neighborhood definition comes from either ``self.graph`` or from
         ``geometry`` + (``bandwidth``, ``fixed``, ``kernel``, ``include_focal``).
         """
-            if _routing_enabled():
+    if _routing_enabled():
                 self.set_fit_request(geometry=True)
 
-        
         self._start = time()
-
         self.geometry = geometry
 
         def _is_binary(series: pd.Series) -> bool:

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -709,7 +709,7 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         self._empty_feature_imp = None
 
     def fit(
-        self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None
+        self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None,**kwargs
     ) -> "BaseClassifier":
         """Fit geographically weighted local classification models.
 
@@ -1442,7 +1442,7 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         self.random_state = random_state
 
     def fit(
-        self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None
+        self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None,**kwargs
     ) -> "BaseRegressor":
         """Fit geographically weighted local regression models.
 

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -6,10 +6,11 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
-from sklearn.linear_model import LinearRegression,LogisticRegression
+from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.utils.metadata_routing import _MetadataRequester
 
 from .base import BaseClassifier, BaseRegressor
+
 class GWLogisticRegression(BaseClassifier, _MetadataRequester):
     """Geographically weighted logistic regression
 

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -7,11 +7,11 @@ import numpy as np
 import pandas as pd
 from libpysal import graph
 from sklearn.linear_model import LinearRegression, LogisticRegression
-from sklearn.utils.metadata_routing import _MetadataRequester
+
 
 from .base import BaseClassifier, BaseRegressor
 
-class GWLogisticRegression(BaseClassifier, _MetadataRequester):
+class GWLogisticRegression(BaseClassifier):
     """Geographically weighted logistic regression
 
     Fits one :class:`sklearn.linear_model.LogisticRegression` per focal observation
@@ -47,7 +47,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         further spatial analysis of the model performance (and generalises to models
         that do not support OOB scoring). However, it leaves out the most representative
         sample. By default True
-   graph : Graph, optional
+    graph : Graph, optional
         Custom libpysal.graph.Graph object encoding the spatial interaction between
         observations in the sample. If given, it is used directly and ``bandwidth``,
         ``fixed``, ``kernel``, and ``include_focal`` keywords are ignored. Either
@@ -218,12 +218,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         )
 
         self._model_type = "logistic"
-    def fit(self,
-            X: pd.DataFrame,
-            y: pd.Series,
-            geometry=None,
-            **_fit_params
-           ):
+    def fit(self,X: pd.DataFrame,y: pd.Series,geometry=None,**_fit_params):
         self.set_fit_request(geometry=True)
         self.set_score_request(geometry=True)
         if geometry is not None:
@@ -240,7 +235,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
             np.array([np.nan]),
         )  # intercept
 
-        super().fit(X=X, y=y, geometry= self.geometry, **fit_params)
+        super().fit(X=X, y=y, geometry= self.geometry, **_fit_params)
 
         self.local_coef_ = pd.concat(
             [x[2] for x in self._score_data], axis=1, keys=self._names
@@ -285,7 +280,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         )
 
 
-class GWLinearRegression(BaseRegressor, _MetadataRequester):
+class GWLinearRegression(BaseRegressor):
     """Geographically weighted linear regression
 
     Fits one :class:`sklearn.linear_model.LinearRegression` per focal observation
@@ -442,7 +437,7 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
             fixed=fixed,
             kernel=kernel,
             include_focal=include_focal,
-            geometry=geometry,
+            geometry=None,
             graph=graph,
             n_jobs=n_jobs,
             fit_global_model=fit_global_model,
@@ -455,10 +450,6 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
         )
 
         self._model_type = "linear"
-        self.set_fit_request(geometry=True)
-        #self.set_predict_request(geometry=True)
-        self.set_score_request(geometry=True)
-
     def _get_score_data(self, local_model, X, y):  # noqa: ARG002
         return (
             pd.Series(
@@ -468,7 +459,10 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
             local_model.intercept_,  # intercept
         )
 
-    def fit(self, X: pd.DataFrame, y: pd.Series, geometry=None, **fit_params):
+    def fit(self, X: pd.DataFrame, y: pd.Series, geometry=None, **_fit_params):
+        self.set_fit_request(geometry=True)
+        #self.set_predict_request(geometry=True)
+        self.set_score_request(geometry=True)
         if geometry is not None:
             self.geometry = geometry
         if isinstance(X, pd.DataFrame):
@@ -480,7 +474,7 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
             np.array([np.nan]),
         )  # intercept
 
-        super().fit(X=X, y=y, geometry=self.geometry, **fit_params)
+        super().fit(X=X, y=y, geometry=self.geometry, **_fit_params)
 
         self.local_coef_ = pd.concat(
             [x[0] for x in self._score_data], axis=1, keys=self._names

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -150,7 +150,6 @@ class GWLogisticRegression(BaseClassifier):
     >>> gw = GWLogisticRegression(
     ...     bandwidth=30,
     ...     fixed=False,
-    ...     geometry=gdf.representative_point(),
     ...     keep_models=True,
     ...     max_iter=200,
     ... ).fit(X, y, geometry=gdf.representative_point())

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -319,7 +319,6 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
         further spatial analysis of the model performance (and generalises to models
         that do not support OOB scoring). However, it leaves out the most representative
         sample. By default True
-    
     graph : Graph, optional
         Custom libpysal.graph.Graph object encoding the spatial interaction between
         observations in the sample. If given, it is used directly and ``bandwidth``,

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -9,7 +9,7 @@ from libpysal import graph
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.utils.metadata_routing import _MetadataRequester
 from .base import BaseClassifier, BaseRegressor
-LogisticRegression(BaseClassifier, _MetadataRequester):
+class LogisticRegression(BaseClassifier, _MetadataRequester):
     """Geographically weighted logistic regression
 
     Fits one :class:`sklearn.linear_model.LogisticRegression` per focal observation
@@ -217,7 +217,7 @@ LogisticRegression(BaseClassifier, _MetadataRequester):
         )
 
         self._model_type = "logistic"
-        def fit(self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None):
+    def fit(self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None):
         # INTERNAL ROUTING SETUP
         # This tells Scikit-Learn that this estimator expects 'geometry'
         self.set_fit_request(geometry=True)

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -218,14 +218,14 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         )
 
         self._model_type = "logistic"
-    def fit(self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None):
-        # INTERNAL ROUTING SETUP
-        # This tells Scikit-Learn that this estimator expects 'geometry'
+    def fit(self,
+            X: pd.DataFrame,
+            y: pd.Series,
+            geometry=None,
+            **_fit_params
+           ):
         self.set_fit_request(geometry=True)
-       # self.set_predict_request(geometry=True)
         self.set_score_request(geometry=True)
-
-    def fit(self, X: pd.DataFrame, y: pd.Series, geometry=None, **fit_params):
         if geometry is not None:
             self.geometry = geometry
         if isinstance(X, pd.DataFrame):

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import LinearRegression,LogisticRegression
 from sklearn.utils.metadata_routing import _MetadataRequester
 
 from .base import BaseClassifier, BaseRegressor
-class LogisticRegression(BaseClassifier, _MetadataRequester):
+class GWLogisticRegression(BaseClassifier, _MetadataRequester):
     """Geographically weighted logistic regression
 
     Fits one :class:`sklearn.linear_model.LogisticRegression` per focal observation

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -10,6 +10,7 @@ from sklearn.linear_model import LinearRegression, LogisticRegression
 
 from .base import BaseClassifier, BaseRegressor
 
+
 class GWLogisticRegression(BaseClassifier):
     """Geographically weighted logistic regression
 
@@ -482,7 +483,7 @@ class GWLinearRegression(BaseRegressor):
         )
 
         return self
-    def score(self, X, y, geometry=None, **score_params):
+    def score(self, X, y, geometry=None, **_score_params):
         """Standard scoring that accepts metadata to prevent routing errors."""
         from sklearn.metrics import r2_score
         # Metadata routing will pass geometry here automatically

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -6,8 +6,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
-from sklearn.linear_model import LinearRegression
-from sklearn.linear_model import LogisticRegression 
+from sklearn.linear_model import LinearRegression,LogisticRegression
 from sklearn.utils.metadata_routing import _MetadataRequester
 
 from .base import BaseClassifier, BaseRegressor

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -9,9 +9,7 @@ from libpysal import graph
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.utils.metadata_routing import _MetadataRequester
 from .base import BaseClassifier, BaseRegressor
-
-
-class GWLogisticRegression(BaseClassifier, _MetadataRequester):
+LogisticRegression(BaseClassifier, _MetadataRequester):
     """Geographically weighted logistic regression
 
     Fits one :class:`sklearn.linear_model.LogisticRegression` per focal observation
@@ -47,12 +45,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         further spatial analysis of the model performance (and generalises to models
         that do not support OOB scoring). However, it leaves out the most representative
         sample. By default True
-    geometry : gpd.GeoSeries, optional
-        Geographic location of the observations in the sample. Used to determine the
-        spatial interaction weight based on specification by ``bandwidth``, ``fixed``,
-        ``kernel``, and ``include_focal`` keywords.  Either ``geometry`` or ``graph``
-        need to be specified. To allow prediction, it is required to specify
-        ``geometry``.
+    
     graph : Graph, optional
         Custom libpysal.graph.Graph object encoding the spatial interaction between
         observations in the sample. If given, it is used directly and ``bandwidth``,
@@ -160,7 +153,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
     ...     geometry=gdf.representative_point(),
     ...     keep_models=True,
     ...     max_iter=200,
-    ... ).fit(X, y)
+    ... ).fit(X, y, geometry=gdf.representative_point())
     >>> gw.pred_.head()
     0     True
     1    False
@@ -187,7 +180,6 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         ]
         | Callable = "bisquare",
         include_focal: bool = True,
-        geometry: gpd.GeoSeries | None = None,
         graph: graph.Graph | None = None,
         n_jobs: int = -1,
         fit_global_model: bool = True,
@@ -225,6 +217,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         )
 
         self._model_type = "logistic"
+        def fit(self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None):
         # INTERNAL ROUTING SETUP
         # This tells Scikit-Learn that this estimator expects 'geometry'
         self.set_fit_request(geometry=True)
@@ -325,12 +318,7 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
         further spatial analysis of the model performance (and generalises to models
         that do not support OOB scoring). However, it leaves out the most representative
         sample. By default True
-    geometry : gpd.GeoSeries, optional
-        Geographic location of the observations in the sample. Used to determine the
-        spatial interaction weight based on specification by ``bandwidth``, ``fixed``,
-        ``kernel``, and ``include_focal`` keywords.  Either ``geometry`` or ``graph``
-        need to be specified. To allow prediction, it is required to specify
-        ``geometry``.
+    
     graph : Graph, optional
         Custom libpysal.graph.Graph object encoding the spatial interaction between
         observations in the sample. If given, it is used directly and ``bandwidth``,
@@ -412,8 +400,7 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
     >>> gwr = GWLinearRegression(
     ...     bandwidth=30,
     ...     fixed=False,
-    ...     geometry=gdf.representative_point(),
-    ... ).fit(X, y)
+    ... ).fit(X, y, geometry=gdf.representative_point())
     >>> gwr.local_r2_.head()
     0    0.614715
     1    0.488495
@@ -439,7 +426,6 @@ class GWLinearRegression(BaseRegressor, _MetadataRequester):
         ]
         | Callable = "bisquare",
         include_focal: bool = True,
-        geometry: gpd.GeoSeries | None = None,
         graph: graph.Graph | None = None,
         n_jobs: int = -1,
         fit_global_model: bool = True,

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -47,8 +47,7 @@ class GWLogisticRegression(BaseClassifier, _MetadataRequester):
         further spatial analysis of the model performance (and generalises to models
         that do not support OOB scoring). However, it leaves out the most representative
         sample. By default True
-    
-    graph : Graph, optional
+   graph : Graph, optional
         Custom libpysal.graph.Graph object encoding the spatial interaction between
         observations in the sample. If given, it is used directly and ``bandwidth``,
         ``fixed``, ``kernel``, and ``include_focal`` keywords are ignored. Either

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -8,7 +8,10 @@ import pandas as pd
 from libpysal import graph
 from sklearn.linear_model import LinearRegression, LogisticRegression 
 from sklearn.utils.metadata_routing import _MetadataRequester
+
 from .base import BaseClassifier, BaseRegressor
+
+
 class LogisticRegression(BaseClassifier, _MetadataRequester):
     """Geographically weighted logistic regression
 

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -6,7 +6,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
-from sklearn.linear_model import LinearRegression, LogisticRegression as SklearnLogisticRegression
+from sklearn.linear_model import LinearRegression, LogisticRegression 
 from sklearn.utils.metadata_routing import _MetadataRequester
 from .base import BaseClassifier, BaseRegressor
 class LogisticRegression(BaseClassifier, _MetadataRequester):

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -2,14 +2,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
 from sklearn.linear_model import LinearRegression, LogisticRegression
 
 from .base import BaseClassifier, BaseRegressor
-
 
 class GWLogisticRegression(BaseClassifier):
     """Geographically weighted logistic regression

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -6,12 +6,11 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
-from sklearn.linear_model import LinearRegression, LogisticRegression 
+from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import LogisticRegression 
 from sklearn.utils.metadata_routing import _MetadataRequester
 
 from .base import BaseClassifier, BaseRegressor
-
-
 class LogisticRegression(BaseClassifier, _MetadataRequester):
     """Geographically weighted logistic regression
 

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -8,7 +8,6 @@ import pandas as pd
 from libpysal import graph
 from sklearn.linear_model import LinearRegression, LogisticRegression
 
-
 from .base import BaseClassifier, BaseRegressor
 
 class GWLogisticRegression(BaseClassifier):

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -6,7 +6,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
-from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.linear_model import LinearRegression, LogisticRegression as SklearnLogisticRegression
 from sklearn.utils.metadata_routing import _MetadataRequester
 from .base import BaseClassifier, BaseRegressor
 class LogisticRegression(BaseClassifier, _MetadataRequester):
@@ -200,7 +200,7 @@ class LogisticRegression(BaseClassifier, _MetadataRequester):
             fixed=fixed,
             kernel=kernel,
             include_focal=include_focal,
-            geometry=geometry,
+            geometry=None,
             graph=graph,
             n_jobs=n_jobs,
             fit_global_model=fit_global_model,


### PR DESCRIPTION
Internal metadata routing for geometry in GWLinearRegression, aligning gwlearn estimators with scikit-learn’s metadata routing API and avoiding the need for user-level set_*_request calls.
Core Changes
1. **Internal Request Configuration**
I have updated GWLinearRegression and GWLogisticRegression to be Metadata Consumers. I called the following methods internally within __init__:
self.set_fit_request(geometry=True)
self.set_score_request(geometry=True)
By setting these internally, users no longer need to manually call these methods when setting up a GridSearchCV.

2. **Updated Model Signatures**
**linear_model.py:** Updated fit methods to explicitly accept geometry=None and **fit_params. This ensures that when GridSearchCV passes spatial folds, the estimator captures them and assigns them to self.geometry before calling the parent fit.
**base.py:** (upcoming commit) Updated base class fit signatures to accept **kwargs to prevent TypeError during the metadata delegation process.

Validation
Verified using the geoda.guerry dataset. The following workflow now completes without TypeError

