### PR TITLE
Fix strict type annotation in GWLogisticRegression

### DIFF
--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -183,7 +183,7 @@ class GWLogisticRegression(BaseClassifier):
         graph: graph.Graph | None = None,
         n_jobs: int = -1,
         fit_global_model: bool = True,
-        strict: bool = False,
+        strict: bool | None = False,
         keep_models: bool | str | Path = False,
         temp_folder: str | None = None,
         batch_size: int | None = None,


### PR DESCRIPTION
`GWLogisticRegression` accepts `strict=None` at runtime and documents it as such,
but the constructor type annotation restricts `strict` to `bool`.

This PR aligns the annotation with actual behavior and with
`GWLinearRegression`.