### PR TITLE
REF: Add type hints to internal _get_score_data method

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -488,7 +488,12 @@ class _BaseModel(BaseEstimator):
     def fit(self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None):
         raise NotImplementedError("Subclasses must implement fit")
 
-    def _get_score_data(self, local_model, X, y):  # noqa: ARG002
+    def _get_score_data(
+        self,
+        local_model: BaseEstimator,  # noqa: ARG002
+        X: pd.DataFrame,  # noqa: ARG002
+        y: pd.Series,  # noqa: ARG002
+    ) -> float | tuple:
         """Subclasses should implement custom function"""
         return np.nan
 

--- a/gwlearn/ensemble.py
+++ b/gwlearn/ensemble.py
@@ -7,6 +7,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
+from sklearn.base import BaseEstimator
 from sklearn.ensemble import (
     GradientBoostingClassifier,
     GradientBoostingRegressor,
@@ -296,7 +297,12 @@ class GWRandomForestClassifier(BaseClassifier):
 
         return self
 
-    def _get_score_data(self, local_model, X, y):  # noqa: ARG002
+    def _get_score_data(
+        self,
+        local_model: BaseEstimator,
+        X: pd.DataFrame,  # noqa: ARG002
+        y: pd.Series,  # noqa: ARG002
+    ) -> float:
         return local_model.oob_score_
 
 
@@ -783,7 +789,12 @@ class GWRandomForestRegressor(BaseRegressor):
 
         return self
 
-    def _get_score_data(self, local_model, X, y):  # noqa: ARG002
+    def _get_score_data(
+        self,
+        local_model: BaseEstimator,
+        X: pd.DataFrame,  # noqa: ARG002
+        y: pd.Series,  # noqa: ARG002
+    ) -> float:
         return local_model.oob_score_
 
 

--- a/gwlearn/linear_model.py
+++ b/gwlearn/linear_model.py
@@ -6,6 +6,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from libpysal import graph
+from sklearn.base import BaseEstimator
 from sklearn.linear_model import LinearRegression, LogisticRegression
 
 from .base import BaseClassifier, BaseRegressor
@@ -261,8 +262,11 @@ class GWLogisticRegression(BaseClassifier):
         return self
 
     def _get_score_data(
-        self, local_model: LogisticRegression, X: pd.DataFrame, y: pd.Series
-    ):
+        self,
+        local_model: BaseEstimator,
+        X: pd.DataFrame,
+        y: pd.Series,
+    ) -> tuple:
         local_proba = pd.DataFrame(
             local_model.predict_proba(X), columns=local_model.classes_
         )
@@ -447,7 +451,12 @@ class GWLinearRegression(BaseRegressor):
 
         self._model_type = "linear"
 
-    def _get_score_data(self, local_model, X, y):  # noqa: ARG002
+    def _get_score_data(
+        self,
+        local_model: BaseEstimator,
+        X: pd.DataFrame,  # noqa: ARG002
+        y: pd.Series,  # noqa: ARG002
+    ) -> tuple:
         return (
             pd.Series(
                 local_model.coef_.flatten(),


### PR DESCRIPTION
This PR adds type hints to the internal `_get_score_data` helper method in `gwlearn/linear_model.py`.

It updates the signature to explicit types (`LogisticRegression`, `pd.DataFrame`, `pd.Series`) to improve readability and IntelliSense support.

Tested locally with `pytest`.