### PR TITLE
DOC: fix outdated BaseRegressor prediction docstring

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -1276,9 +1276,6 @@ class BaseRegressor(_BaseModel, RegressorMixin):
     The fitted object exposes focal predictions (``pred_``,  in-sample if
     ``include_focal=True``) and local goodness-of-fit summaries.
 
-    Prediction for new (out-of-sample) observations is not currently implemented for
-    regressors.
-
     Notes
     -----
     - Only point geometries are supported.


### PR DESCRIPTION
The BaseRegressor class docstring stated that prediction on out-of-sample observations is not supported. However, predict() does support this when keep_models=True. This PR updates the docstring to reflect the current implementation.