### PR TITLE
Add structured fit-time input validation

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -474,7 +474,6 @@ class _BaseModel(BaseEstimator):
         """
         raise NotImplementedError("Subclasses must implement _predict_local")
 
-    # Abstract methods that subclasses must implement
     def _validate_fit_inputs(
         self,
         X: pd.DataFrame,
@@ -521,6 +520,7 @@ class _BaseModel(BaseEstimator):
             if not self.fixed and not isinstance(self.bandwidth, int):
                 raise ValueError("Adaptive bandwidth (fixed=False) must be an integer.")
 
+    # Abstract methods that subclasses must implement
     def _fit_local(
         self,
         model,

--- a/gwlearn/tests/test_base.py
+++ b/gwlearn/tests/test_base.py
@@ -292,12 +292,7 @@ def test_fit_without_global_model(sample_data):
 
 
 def test_fit_negative_bandwidth_raises(sample_data):
-    """
-    Test that a negative bandwidth raises a ValueError during fit.
-
-    Bandwidth validation is performed inside the fit() method
-    (not during initialization), following sklearn-style design.
-    """
+    """Negative bandwidth raises ValueError in fit()."""
     X, y, geometry = sample_data
 
     # Initialize with invalid negative bandwidth
@@ -313,13 +308,7 @@ def test_fit_negative_bandwidth_raises(sample_data):
 
 
 def test_fit_adaptive_bandwidth_must_be_integer(sample_data):
-    """
-    Test that adaptive bandwidth (fixed=False) must be an integer.
-
-    When using adaptive bandwidth, the bandwidth represents
-    the number of nearest neighbors and therefore must be an integer.
-    Validation is performed during fit().
-    """
+    """Adaptive bandwidth must be an integer when fixed=False."""
     X, y, geometry = sample_data
 
     # Initialize with non-integer adaptive bandwidth
@@ -335,12 +324,7 @@ def test_fit_adaptive_bandwidth_must_be_integer(sample_data):
 
 
 def test_fit_length_mismatch_raises(sample_data):
-    """
-    Test that fit() raises ValueError when X and y
-    have different lengths.
-
-    This validates basic structural consistency of input data.
-    """
+    """fit() raises ValueError when X and y have different lengths."""
     X, y, geometry = sample_data
 
     # Remove last observation from y
@@ -359,12 +343,7 @@ def test_fit_length_mismatch_raises(sample_data):
 
 
 def test_fit_requires_geometry_or_graph(sample_data):
-    """
-    Test that fit() raises ValueError when neither
-    geometry nor graph is provided.
-
-    The model requires at least one spatial structure.
-    """
+    """fit() raises ValueError when neither geometry nor graph is provided."""
     X, y, _ = sample_data
 
     clf = BaseClassifier(
@@ -381,12 +360,7 @@ def test_fit_requires_geometry_or_graph(sample_data):
 
 
 def test_fit_geometry_length_mismatch_raises(sample_data):
-    """
-    Test that fit() raises ValueError when geometry
-    length does not match X length.
-
-    Ensures spatial data aligns with observations.
-    """
+    """fit() raises ValueError when geometry length mismatches X."""
     X, y, geometry = sample_data
 
     # Remove last geometry row to create mismatch


### PR DESCRIPTION
**### Description**

This PR introduces structured input validation within the fit() method of BaseClassifier and BaseRegressor. The changes improve robustness and enforce structural and spatial consistency before model training begins.

Validation is performed at fit-time, following scikit-learn design conventions.

**### Modifications**
**1. Added _validate_fit_inputs method**

Introduced a centralized validation helper to ensure input correctness prior to model fitting.

**2. Implemented the following validation checks:**

- X–y Length Consistency
Ensures X and y contain the same number of observations, preventing misaligned feature–target mappings.

- Presence of Spatial Structure
 Requires at least one spatial input (geometry or graph) to be provided, ensuring geographically weighted models are not fit without defined spatial relationships.

- Geometry Length Alignment
  When geometry is provided, its length must match the number of rows in X, ensuring each observation has a corresponding spatial location.

- Positive Bandwidth Enforcement
   Ensures bandwidth > 0. Non-positive bandwidth values are mathematically invalid     for spatial kernel computations.

- Integer Adaptive Bandwidth Enforcement
 When fixed=False (adaptive mode), bandwidth must be an integer since it represents the number of nearest neighbors.

**3. Binary Target Validation Ordering**

Adjusted the validation flow in BaseClassifier.fit() to ensure binary target validation occurs before spatial validation, aligning with expected test behavior and enabling early failure for invalid targets.

**4. Documentation**

Added docstrings to improve clarity and maintainability.

**### Motivation**

These changes enforce early validation of invalid configurations, prevent inconsistent model states, and improve the reliability of geographically weighted model fitting.

Performing validation during fit() aligns with scikit-learn design principles, particularly ensuring target validation precedes spatial validation checks.

**### Tests**

- Added new unit tests covering:
     Negative bandwidth
      Non-integer adaptive bandwidth
- All existing tests pass.
- Code formatted with black
- Lint checks pass with ruff