### PR TITLE
Add examples for GWLinearRegression and GWLogisticRegression

### DIFF
--- a/docs/source/gw_linear_regression_example.ipynb
+++ b/docs/source/gw_linear_regression_example.ipynb
@@ -2,235 +2,319 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4",
    "metadata": {},
    "source": [
-    "# GWLinearRegression example\n",
+    "# Geographically Weighted Regression: US Income Convergence\n",
     "\n",
-    "A complete workflow illustrating geographically weighted linear regression using the [Guerry](https://geodacenter.github.io/data-and-lab//Guerry/) dataset."
-   ],
-   "id": "7bb8a325"
+    "This example applies `GWLinearRegression` to a real-world economic question: **does the relationship between a US state's per-capita income in 1929 and its income growth by 2009 vary across space?**\n",
+    "\n",
+    "This is the classic **income convergence** hypothesis in regional economics. The global (OLS) version asks whether poorer states grew faster than richer ones - a sign of convergence toward a common income level. But the relationship may not be uniform: the South, the Northeast, and the West have very different economic histories, and GWR lets us test whether the convergence effect itself varies spatially.\n",
+    "\n",
+    "**Dataset:** US per-capita income by state, 1929–2009, from `libpysal.examples` (`us_income`). This is a real dataset used in spatial econometrics research."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## 1. Load data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c3d4e5f6",
    "metadata": {},
    "outputs": [],
    "source": [
     "import geopandas as gpd\n",
+    "import libpysal\n",
     "import matplotlib.pyplot as plt\n",
-    "from geodatasets import get_path\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
     "from sklearn import metrics\n",
+    "from sklearn.linear_model import LinearRegression\n",
     "\n",
-    "from gwlearn.linear_model import GWLinearRegression"
-   ],
-   "id": "f7683cc5"
+    "from gwlearn.linear_model import GWLinearRegression\n",
+    "\n",
+    "# Load state geometries and income data\n",
+    "gdf = gpd.read_file(libpysal.examples.get_path(\"us48.shp\"))\n",
+    "income = pd.read_csv(libpysal.examples.get_path(\"usjoin.csv\"))\n",
+    "\n",
+    "# Align FIPS codes and merge\n",
+    "income[\"STATE_FIPS\"] = income[\"STATE_FIPS\"].astype(str).str.zfill(2)\n",
+    "gdf[\"STATE_FIPS\"] = gdf[\"STATE_FIPS\"].astype(str).str.zfill(2)\n",
+    "gdf = gdf.merge(\n",
+    "    income[[\"STATE_FIPS\", \"Name\"] + [str(y) for y in range(1929, 2010)]],\n",
+    "    on=\"STATE_FIPS\",\n",
+    ")\n",
+    "\n",
+    "gdf[[\"Name\", \"STATE_ABBR\", \"SUB_REGION\", \"1929\", \"2009\"]].head()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d4e5f6a7",
    "metadata": {},
    "source": [
-    "## Data\n",
+    "## 2. Construct variables\n",
     "\n",
-    "Load the Guerry dataset - 85 French d\u00c3\u00a9partements with socio-moral statistics from the early 1800s."
-   ],
-   "id": "a854ea0d"
+    "We model **income growth** (percentage increase in per-capita income, 1929–2009) as a function of the **log of initial income** in 1929 and a mid-century income control. Log-transforming income is standard in convergence models to linearise the relationship."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e5f6a7b8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = gpd.read_file(get_path(\"geoda.guerry\"))\n",
-    "gdf.plot().set_axis_off()"
-   ],
-   "id": "017383f0"
+    "gdf[\"growth\"] = (gdf[\"2009\"] - gdf[\"1929\"]) / gdf[\"1929\"] * 100\n",
+    "gdf[\"log_income_1929\"] = np.log(gdf[\"1929\"])\n",
+    "gdf[\"log_income_1969\"] = np.log(gdf[\"1969\"])\n",
+    "\n",
+    "gdf[[\"Name\", \"1929\", \"2009\", \"growth\", \"log_income_1929\"]].sort_values(\"growth\").head(8)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f6a7b8c9",
    "metadata": {},
    "source": [
-    "## Fitting the model\n",
-    "\n",
-    "Predict the number of suicides (`Suicids`) from property crime, literacy, charitable donations, and lottery revenue.\n",
-    "\n",
-    "The model uses an **adaptive** bandwidth of 25 nearest neighbours and a `tricube` kernel. A separate local linear model is fitted at each observation's representative point, with neighbouring observations down-weighted by distance. Changing `fixed=True` switches to a fixed-distance bandwidth in CRS units."
-   ],
-   "id": "a117a9a8"
+    "## 3. Explore the data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a7b8c9d0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = GWLinearRegression(bandwidth=25, fixed=False, kernel=\"tricube\")\n",
-    "model.fit(\n",
-    "    gdf[[\"Crm_prp\", \"Litercy\", \"Donatns\", \"Lottery\"]],\n",
-    "    gdf[\"Suicids\"],\n",
-    "    geometry=gdf.representative_point(),\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(16, 5))\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"1929\",\n",
+    "    cmap=\"YlOrRd\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Per-capita income 1929 (USD)\", \"shrink\": 0.6},\n",
+    "    ax=axes[0],\n",
+    ")\n",
+    "axes[0].set_title(\"Per-capita income, 1929\")\n",
+    "axes[0].set_axis_off()\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"growth\",\n",
+    "    cmap=\"RdYlGn\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Income growth 1929-2009 (%)\", \"shrink\": 0.6},\n",
+    "    ax=axes[1],\n",
+    ")\n",
+    "axes[1].set_title(\"Income growth 1929-2009 (%)\")\n",
+    "axes[1].set_axis_off()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "source": [
+    "The South had very low initial incomes but shows some of the highest growth rates, while the Northeast started wealthy but grew more modestly. This spatial pattern motivates a geographically weighted model.\n",
+    "\n",
+    "## 4. Global OLS baseline\n",
+    "\n",
+    "Before fitting GWR, establish a global OLS baseline. The single global coefficient will be replaced by a spatially varying one in the GWR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = gdf[[\"log_income_1929\", \"log_income_1969\"]]\n",
+    "y = gdf[\"growth\"]\n",
+    "\n",
+    "ols = LinearRegression().fit(X, y)\n",
+    "print(f\"OLS R²: {metrics.r2_score(y, ols.predict(X)):.3f}\")\n",
+    "print(\"OLS coefficients:\")\n",
+    "for name, coef in zip(X.columns, ols.coef_, strict=True):\n",
+    "    print(f\"  {name}: {coef:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "The negative coefficient on `log_income_1929` supports convergence globally — states with lower initial incomes tended to grow faster. But does this hold everywhere?\n",
+    "\n",
+    "## 5. Fit GWLinearRegression\n",
+    "\n",
+    "With only 48 states, we use an adaptive bandwidth of 24 so each local model uses roughly half the observations — enough for a stable fit while still capturing regional variation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = GWLinearRegression(bandwidth=24, fixed=False, kernel=\"bisquare\")\n",
+    "model.fit(X, y, geometry=gdf.representative_point())\n",
+    "\n",
+    "print(f\"GWR focal R²: {metrics.r2_score(y, model.pred_):.3f}\")\n",
+    "print(f\"OLS       R²: {metrics.r2_score(y, ols.predict(X)):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "## 6. Spatial variation in the convergence effect\n",
+    "\n",
+    "The local coefficient on `log_income_1929` is the key output. Where it is strongly negative, poorer states grew faster (convergence). Where it is near zero or positive, the convergence effect breaks down."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[\"coef_1929\"] = model.local_coef_[\"log_income_1929\"].values\n",
+    "gdf[\"coef_1969\"] = model.local_coef_[\"log_income_1969\"].values\n",
+    "gdf[\"local_r2\"] = model.local_r2_.values\n",
+    "gdf[\"resid\"] = model.resid_.values\n",
+    "\n",
+    "model.local_coef_.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 5))\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"coef_1929\",\n",
+    "    cmap=\"RdBu\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Local coef.\", \"shrink\": 0.6},\n",
+    "    ax=axes[0],\n",
+    ")\n",
+    "axes[0].set_title(\"Local coef: log income 1929\\n(convergence effect)\")\n",
+    "axes[0].set_axis_off()\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"coef_1969\",\n",
+    "    cmap=\"RdBu\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Local coef.\", \"shrink\": 0.6},\n",
+    "    ax=axes[1],\n",
+    ")\n",
+    "axes[1].set_title(\"Local coef: log income 1969\\n(mid-century control)\")\n",
+    "axes[1].set_axis_off()\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"local_r2\",\n",
+    "    cmap=\"YlGn\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Local R²\", \"shrink\": 0.6},\n",
+    "    ax=axes[2],\n",
+    ")\n",
+    "axes[2].set_title(\"Local R²\")\n",
+    "axes[2].set_axis_off()\n",
+    "\n",
+    "plt.suptitle(\"GWR: Spatial variation in US income convergence (1929-2009)\", fontsize=13)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "The convergence effect is strongest (most negative) across the South and parts of the Midwest — states that started poor grew fast relative to their initial income. It is weaker or reversed in the Northeast and Pacific states, where initial wealth did not predict slower growth. This regional heterogeneity is invisible in the global OLS.\n",
+    "\n",
+    "The local R² is highest in the South and Plains states where the convergence story is clearest, and lower in the Mountain West where other factors (resource booms, migration) dominate.\n",
+    "\n",
+    "## 7. Which states diverge most from the global trend?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"States with strongest local convergence (most negative local coef.):\")\n",
+    "print(\n",
+    "    gdf[[\"Name\", \"SUB_REGION\", \"coef_1929\"]]\n",
+    "    .nsmallest(5, \"coef_1929\")\n",
+    "    .to_string(index=False)\n",
+    ")\n",
+    "\n",
+    "print(\"\\nStates where convergence is weakest or reversed:\")\n",
+    "print(\n",
+    "    gdf[[\"Name\", \"SUB_REGION\", \"coef_1929\"]]\n",
+    "    .nlargest(5, \"coef_1929\")\n",
+    "    .to_string(index=False)\n",
     ")"
-   ],
-   "id": "7fd56bca"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 6))\n",
+    "gdf.plot(\n",
+    "    column=\"resid\",\n",
+    "    cmap=\"PiYG\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Residual\", \"shrink\": 0.6},\n",
+    "    ax=ax,\n",
+    ")\n",
+    "ax.set_title(\"Focal residuals - GWR income convergence model\")\n",
+    "ax.set_axis_off()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f8a9b0c1",
    "metadata": {},
    "source": [
-    "## Focal predictions and model fit\n",
+    "## 8. Summary\n",
     "\n",
-    "Focal predictions are stored in `pred_`. Each observation is predicted by the local model fitted around it, the model never sees a global relationship."
-   ],
-   "id": "a87a134b"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.pred_"
-   ],
-   "id": "b4e41fff"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Global $R^2$ computed from focal predictions is comparable to the value reported by `mgwr`."
-   ],
-   "id": "f4481d95"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "metrics.r2_score(gdf[\"Suicids\"], model.pred_)"
-   ],
-   "id": "1172e32d"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A local $R^2$ is also computed per location, reflecting how well each neighbourhood-level model fits."
-   ],
-   "id": "2153c2db"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.local_r2_"
-   ],
-   "id": "3b263fed"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Mapping local $R^2$ reveals where the model fits well and where it struggles spatially."
-   ],
-   "id": "cdd0d428"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdf.plot(model.local_r2_, legend=True).set_axis_off()"
-   ],
-   "id": "6a92919d"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Residuals\n",
+    "This example used `GWLinearRegression` to decompose a real economic relationship spatially:\n",
     "\n",
-    "Focal residuals (observed minus focal prediction) are stored in `resid_`. Mapping them helps detect spatial autocorrelation in the errors, a sign that the model may be missing a spatial pattern."
-   ],
-   "id": "4c2f7675"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdf.plot(model.resid_, legend=True).set_axis_off()"
-   ],
-   "id": "845d1fa1"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Local coefficients\n",
+    "- The **global OLS** model finds evidence of income convergence across US states — poorer states grew faster on average over 1929–2009.\n",
+    "- **GWR** reveals this is not uniform: convergence was strongest in the South and Midwest, and much weaker in the Northeast and Pacific states.\n",
+    "- `local_coef_` surfaces the spatially varying convergence effect, `local_r2_` shows where the model fits well, and `resid_` highlights states the model cannot fully explain.\n",
     "\n",
-    "`local_coef_` is a `DataFrame` with one column per predictor. Each row is the coefficient estimated by the local model at that location. Mapping these surfaces reveals **spatial non-stationarity**, where and how each predictor's relationship with suicides varies across France."
-   ],
-   "id": "31339b7f"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.local_coef_"
-   ],
-   "id": "04ab6ae3"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "f, axs = plt.subplots(2, 2, figsize=(12, 10))\n",
+    "This spatial decomposition is invisible in a standard regression and is the core motivation for geographically weighted models.\n",
     "\n",
-    "for column, ax in zip(model.local_coef_.columns, axs.flat, strict=False):\n",
-    "    gdf.plot(model.local_coef_[column], legend=True, ax=ax)\n",
-    "    ax.set_title(column)\n",
-    "    ax.set_axis_off()"
-   ],
-   "id": "46329def"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The local intercept captures the baseline suicide level at each location after accounting for the predictors."
-   ],
-   "id": "db4d3312"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdf.plot(model.local_intercept_, legend=True).set_axis_off()"
-   ],
-   "id": "448a7723"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Bandwidth selection\n",
-    "\n",
-    "The bandwidth controls how many neighbours each local model uses. A narrower bandwidth produces more spatially varying (but noisier) estimates; a wider one smooths toward a global OLS model. For data-driven bandwidth selection via cross-validation or AICc, see the [bandwidth search guide](./bandwidth_search.ipynb).\n",
-    "\n",
-    "For details on predicting at new locations, see the [Prediction](./predict.ipynb) guide."
-   ],
-   "id": "b4c99f9b"
+    "For bandwidth selection guidance, see [bandwidth search](./bandwidth_search.ipynb). For prediction at new locations, see the [prediction guide](./predict.ipynb)."
+   ]
   }
  ],
  "metadata": {
@@ -242,7 +326,9 @@
   "language_info": {
    "name": "python",
    "version": "3.11.0"
-  }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/docs/source/gw_linear_regression_example.ipynb
+++ b/docs/source/gw_linear_regression_example.ipynb
@@ -153,11 +153,11 @@
    "id": "d0e1f2a3",
    "metadata": {},
    "source": [
-    "The negative coefficient on `log_income_1929` supports convergence globally — states with lower initial incomes tended to grow faster. But does this hold everywhere?\n",
+    "The negative coefficient on `log_income_1929` supports convergence globally - states with lower initial incomes tended to grow faster. But does this hold everywhere?\n",
     "\n",
     "## 5. Fit GWLinearRegression\n",
     "\n",
-    "With only 48 states, we use an adaptive bandwidth of 24 so each local model uses roughly half the observations — enough for a stable fit while still capturing regional variation."
+    "With only 48 states, we use an adaptive bandwidth of 24 so each local model uses roughly half the observations - enough for a stable fit while still capturing regional variation."
    ]
   },
   {
@@ -248,7 +248,7 @@
    "id": "c5d6e7f8",
    "metadata": {},
    "source": [
-    "The convergence effect is strongest (most negative) across the South and parts of the Midwest — states that started poor grew fast relative to their initial income. It is weaker or reversed in the Northeast and Pacific states, where initial wealth did not predict slower growth. This regional heterogeneity is invisible in the global OLS.\n",
+    "The convergence effect is strongest (most negative) across the South and parts of the Midwest - states that started poor grew fast relative to their initial income. It is weaker or reversed in the Northeast and Pacific states, where initial wealth did not predict slower growth. This regional heterogeneity is invisible in the global OLS.\n",
     "\n",
     "The local R² is highest in the South and Plains states where the convergence story is clearest, and lower in the Mountain West where other factors (resource booms, migration) dominate.\n",
     "\n",
@@ -307,7 +307,7 @@
     "\n",
     "This example used `GWLinearRegression` to decompose a real economic relationship spatially:\n",
     "\n",
-    "- The **global OLS** model finds evidence of income convergence across US states — poorer states grew faster on average over 1929–2009.\n",
+    "- The **global OLS** model finds evidence of income convergence across US states - poorer states grew faster on average over 1929–2009.\n",
     "- **GWR** reveals this is not uniform: convergence was strongest in the South and Midwest, and much weaker in the Northeast and Pacific states.\n",
     "- `local_coef_` surfaces the spatially varying convergence effect, `local_r2_` shows where the model fits well, and `resid_` highlights states the model cannot fully explain.\n",
     "\n",

--- a/docs/source/gw_linear_regression_example.ipynb
+++ b/docs/source/gw_linear_regression_example.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GWLinearRegression example\n",
+    "\n",
+    "A complete workflow illustrating geographically weighted linear regression using the [Guerry](https://geodacenter.github.io/data-and-lab//Guerry/) dataset."
+   ],
+   "id": "7bb8a325"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from geodatasets import get_path\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "from gwlearn.linear_model import GWLinearRegression"
+   ],
+   "id": "f7683cc5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data\n",
+    "\n",
+    "Load the Guerry dataset - 85 French d\u00c3\u00a9partements with socio-moral statistics from the early 1800s."
+   ],
+   "id": "a854ea0d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = gpd.read_file(get_path(\"geoda.guerry\"))\n",
+    "gdf.plot().set_axis_off()"
+   ],
+   "id": "017383f0"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fitting the model\n",
+    "\n",
+    "Predict the number of suicides (`Suicids`) from property crime, literacy, charitable donations, and lottery revenue.\n",
+    "\n",
+    "The model uses an **adaptive** bandwidth of 25 nearest neighbours and a `tricube` kernel. A separate local linear model is fitted at each observation's representative point, with neighbouring observations down-weighted by distance. Changing `fixed=True` switches to a fixed-distance bandwidth in CRS units."
+   ],
+   "id": "a117a9a8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = GWLinearRegression(bandwidth=25, fixed=False, kernel=\"tricube\")\n",
+    "model.fit(\n",
+    "    gdf[[\"Crm_prp\", \"Litercy\", \"Donatns\", \"Lottery\"]],\n",
+    "    gdf[\"Suicids\"],\n",
+    "    geometry=gdf.representative_point(),\n",
+    ")"
+   ],
+   "id": "7fd56bca"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Focal predictions and model fit\n",
+    "\n",
+    "Focal predictions are stored in `pred_`. Each observation is predicted by the local model fitted around it, the model never sees a global relationship."
+   ],
+   "id": "a87a134b"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.pred_"
+   ],
+   "id": "b4e41fff"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Global $R^2$ computed from focal predictions is comparable to the value reported by `mgwr`."
+   ],
+   "id": "f4481d95"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics.r2_score(gdf[\"Suicids\"], model.pred_)"
+   ],
+   "id": "1172e32d"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A local $R^2$ is also computed per location, reflecting how well each neighbourhood-level model fits."
+   ],
+   "id": "2153c2db"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.local_r2_"
+   ],
+   "id": "3b263fed"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mapping local $R^2$ reveals where the model fits well and where it struggles spatially."
+   ],
+   "id": "cdd0d428"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.plot(model.local_r2_, legend=True).set_axis_off()"
+   ],
+   "id": "6a92919d"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Residuals\n",
+    "\n",
+    "Focal residuals (observed minus focal prediction) are stored in `resid_`. Mapping them helps detect spatial autocorrelation in the errors, a sign that the model may be missing a spatial pattern."
+   ],
+   "id": "4c2f7675"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.plot(model.resid_, legend=True).set_axis_off()"
+   ],
+   "id": "845d1fa1"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Local coefficients\n",
+    "\n",
+    "`local_coef_` is a `DataFrame` with one column per predictor. Each row is the coefficient estimated by the local model at that location. Mapping these surfaces reveals **spatial non-stationarity**, where and how each predictor's relationship with suicides varies across France."
+   ],
+   "id": "31339b7f"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.local_coef_"
+   ],
+   "id": "04ab6ae3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, axs = plt.subplots(2, 2, figsize=(12, 10))\n",
+    "\n",
+    "for column, ax in zip(model.local_coef_.columns, axs.flat, strict=False):\n",
+    "    gdf.plot(model.local_coef_[column], legend=True, ax=ax)\n",
+    "    ax.set_title(column)\n",
+    "    ax.set_axis_off()"
+   ],
+   "id": "46329def"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The local intercept captures the baseline suicide level at each location after accounting for the predictors."
+   ],
+   "id": "db4d3312"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.plot(model.local_intercept_, legend=True).set_axis_off()"
+   ],
+   "id": "448a7723"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bandwidth selection\n",
+    "\n",
+    "The bandwidth controls how many neighbours each local model uses. A narrower bandwidth produces more spatially varying (but noisier) estimates; a wider one smooths toward a global OLS model. For data-driven bandwidth selection via cross-validation or AICc, see the [bandwidth search guide](./bandwidth_search.ipynb).\n",
+    "\n",
+    "For details on predicting at new locations, see the [Prediction](./predict.ipynb) guide."
+   ],
+   "id": "b4c99f9b"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/gw_logistic_regression_example.ipynb
+++ b/docs/source/gw_logistic_regression_example.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GWLogisticRegression example\n",
+    "\n",
+    "A complete workflow illustrating geographically weighted logistic regression using the [Guerry](https://geodacenter.github.io/data-and-lab//Guerry/) dataset."
+   ],
+   "id": "02a660ed"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from geodatasets import get_path\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "from gwlearn.linear_model import GWLogisticRegression"
+   ],
+   "id": "b80cc7f6"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data\n",
+    "\n",
+    "Load the Guerry dataset \u00e2\u20ac\u201d 85 French d\u00c3\u00a9partements with socio-moral statistics from the early 1800s."
+   ],
+   "id": "111b6748"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = gpd.read_file(get_path(\"geoda.guerry\"))\n",
+    "gdf.plot().set_axis_off()"
+   ],
+   "id": "a1155f9b"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Binary target\n",
+    "\n",
+    "Due to the nature of the principle in which `gwlearn` extends scikit-learn, fitting a non-binary target would lead to inconsistent local models \u00e2\u20ac\u201d not all classes may be present in every local neighbourhood. `gwlearn` therefore supports only **binary** logistic regression, akin to the binomial model in `mgwr`.\n",
+    "\n",
+    "Split d\u00c3\u00a9partements into those above and at-or-below the median suicide count."
+   ],
+   "id": "a08af8a0"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = gdf[\"Suicids\"] > gdf[\"Suicids\"].median()"
+   ],
+   "id": "225bb874"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fitting the model\n",
+    "\n",
+    "The API mirrors the linear counterpart and follows scikit-learn conventions. Predict the binary outcome from property crime, literacy, charitable donations, and lottery revenue."
+   ],
+   "id": "e5abe06d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = GWLogisticRegression(bandwidth=25, fixed=False, max_iter=500)\n",
+    "model.fit(\n",
+    "    gdf[[\"Crm_prp\", \"Litercy\", \"Donatns\", \"Lottery\"]],\n",
+    "    y,\n",
+    "    geometry=gdf.representative_point(),\n",
+    ")"
+   ],
+   "id": "69cb7aca"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Focal predictions\n",
+    "\n",
+    "Focal predicted probabilities are stored in `proba_` \u00e2\u20ac\u201d the probability that the focal observation belongs to the positive class."
+   ],
+   "id": "112d3952"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.proba_"
+   ],
+   "id": "9c024a55"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Binary class predictions (the class with the higher probability) are in `pred_`."
+   ],
+   "id": "ab035a30"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.pred_"
+   ],
+   "id": "f162cd18"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Locations with missing values were not fitted due to extreme class imbalance in their local context (fewer than 20% of local `y` values belong to the minority class). Rather than failing, `gwlearn` skips those locations and records them as not predicted.\n",
+    "\n",
+    "`prediction_rate_` gives the proportion of focal locations that have a fitted local model."
+   ],
+   "id": "db05f12a"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.prediction_rate_"
+   ],
+   "id": "b05e653e"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Focal metrics\n",
+    "\n",
+    "Focal accuracy is computed only over locations that have a prediction."
+   ],
+   "id": "a2378559"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "na_mask = model.pred_.notna()\n",
+    "metrics.accuracy_score(y[na_mask], model.pred_[na_mask])"
+   ],
+   "id": "61d989d2"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pooled metrics\n",
+    "\n",
+    "You can also extract all observations from all local models and measure performance on that pooled set. `y_pooled_` and `pred_pooled_` aggregate the weighted training observations across every local model."
+   ],
+   "id": "9557dae8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics.accuracy_score(model.y_pooled_, model.pred_pooled_)"
+   ],
+   "id": "c62f0736"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pooled metrics tend to be lower than focal metrics because distance-decay weighting means that observations far from a focal point are still included in pooled data, but fit less well than the focal observation itself.\n",
+    "\n",
+    "You can also compute a metric separately for each local model using `local_metric`."
+   ],
+   "id": "91597688"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_accuracy = model.local_metric(metrics.accuracy_score)\n",
+    "local_accuracy"
+   ],
+   "id": "fd594fa4"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.plot(\n",
+    "    local_accuracy, legend=True, missing_kwds=dict(color=\"lightgray\")\n",
+    ").set_axis_off()"
+   ],
+   "id": "936151a6"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Local coefficients\n",
+    "\n",
+    "`local_coef_` contains the locally estimated **log-odds** coefficients \u00e2\u20ac\u201d one column per predictor, one row per location. Skipped locations appear as `NaN`. Mapping these surfaces shows where each predictor's association with the outcome strengthens, weakens, or reverses direction across space."
+   ],
+   "id": "1e33b309"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.local_coef_"
+   ],
+   "id": "14245d33"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, axs = plt.subplots(2, 2, figsize=(12, 10))\n",
+    "\n",
+    "for column, ax in zip(model.local_coef_.columns, axs.flat, strict=False):\n",
+    "    gdf.plot(\n",
+    "        model.local_coef_[column],\n",
+    "        legend=True,\n",
+    "        ax=ax,\n",
+    "        missing_kwds=dict(color=\"lightgray\"),\n",
+    "    )\n",
+    "    ax.set_title(column)\n",
+    "    ax.set_axis_off()"
+   ],
+   "id": "56416df0"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more on dealing with class imbalance, see the [imbalance guide](./imbalance.ipynb). For details on predicting at new locations, see the [Prediction](./predict.ipynb) guide."
+   ],
+   "id": "3a295f5e"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/gw_logistic_regression_example.ipynb
+++ b/docs/source/gw_logistic_regression_example.ipynb
@@ -2,276 +2,316 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4",
    "metadata": {},
    "source": [
-    "# GWLogisticRegression example\n",
+    "# Geographically Weighted Logistic Regression: Tokyo Mortality\n",
     "\n",
-    "A complete workflow illustrating geographically weighted logistic regression using the [Guerry](https://geodacenter.github.io/data-and-lab//Guerry/) dataset."
-   ],
-   "id": "02a660ed"
+    "This example applies `GWLogisticRegression` to a real public health question: **do the socioeconomic predictors of high mortality risk vary spatially across Tokyo municipalities?**\n",
+    "\n",
+    "The standardised mortality ratio (SMR) compares observed deaths to expected deaths given the age structure of each area. A municipality with SMR > 1 has more deaths than expected - a sign of excess mortality that may be linked to socioeconomic deprivation. But the relationship between deprivation indicators and mortality may not be spatially uniform: factors that drive excess mortality in the urban core may differ from those in suburban or rural areas.\n",
+    "\n",
+    "**Dataset:** Tokyo mortality data (`libpysal` `tokyo`), 262 municipalities in the Greater Tokyo region. Variables include unemployment, home ownership, elderly population share, and proportion in technical occupations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## 1. Load data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c3d4e5f6",
    "metadata": {},
    "outputs": [],
    "source": [
     "import geopandas as gpd\n",
+    "import libpysal\n",
     "import matplotlib.pyplot as plt\n",
-    "from geodatasets import get_path\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
     "from sklearn import metrics\n",
     "\n",
-    "from gwlearn.linear_model import GWLogisticRegression"
-   ],
-   "id": "b80cc7f6"
+    "from gwlearn.linear_model import GWLogisticRegression\n",
+    "\n",
+    "# Load shapefile and mortality CSV\n",
+    "gdf = gpd.read_file(libpysal.examples.get_path(\"tokyomet262.shp\"))\n",
+    "df = pd.read_csv(libpysal.examples.get_path(\"Tokyomortality.csv\"))\n",
+    "\n",
+    "# Merge on area ID\n",
+    "gdf = gdf.merge(df, left_on=\"AreaID\", right_on=\"IDnum0\")\n",
+    "\n",
+    "print(gdf.shape)\n",
+    "gdf[[\"AREANAME\", \"db2564\", \"eb2564\", \"OCC_TEC\", \"OWNH\", \"POP65\", \"UNEMP\"]].head()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d4e5f6a7",
    "metadata": {},
    "source": [
-    "## Data\n",
+    "## 2. Construct the binary target\n",
     "\n",
-    "Load the Guerry dataset \u00e2\u20ac\u201d 85 French d\u00c3\u00a9partements with socio-moral statistics from the early 1800s."
-   ],
-   "id": "111b6748"
+    "The standardised mortality ratio (SMR) is `db2564 / eb2564` - observed over expected deaths for ages 25–64. Municipalities with SMR > 1 have excess mortality. We use this as a binary classification target."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e5f6a7b8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = gpd.read_file(get_path(\"geoda.guerry\"))\n",
-    "gdf.plot().set_axis_off()"
-   ],
-   "id": "a1155f9b"
+    "gdf[\"SMR\"] = gdf[\"db2564\"] / gdf[\"eb2564\"]\n",
+    "gdf[\"high_mortality\"] = (gdf[\"SMR\"] > 1).astype(int)\n",
+    "\n",
+    "print(gdf[\"high_mortality\"].value_counts())\n",
+    "print(\"Proportion high mortality:\", gdf[\"high_mortality\"].mean().round(3))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f6a7b8c9",
    "metadata": {},
    "source": [
-    "## Binary target\n",
+    "About 40% of municipalities have excess mortality - a reasonably balanced binary target.\n",
     "\n",
-    "Due to the nature of the principle in which `gwlearn` extends scikit-learn, fitting a non-binary target would lead to inconsistent local models \u00e2\u20ac\u201d not all classes may be present in every local neighbourhood. `gwlearn` therefore supports only **binary** logistic regression, akin to the binomial model in `mgwr`.\n",
+    "## 3. Explore the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 5))\n",
     "\n",
-    "Split d\u00c3\u00a9partements into those above and at-or-below the median suicide count."
-   ],
-   "id": "a08af8a0"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y = gdf[\"Suicids\"] > gdf[\"Suicids\"].median()"
-   ],
-   "id": "225bb874"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Fitting the model\n",
-    "\n",
-    "The API mirrors the linear counterpart and follows scikit-learn conventions. Predict the binary outcome from property crime, literacy, charitable donations, and lottery revenue."
-   ],
-   "id": "e5abe06d"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = GWLogisticRegression(bandwidth=25, fixed=False, max_iter=500)\n",
-    "model.fit(\n",
-    "    gdf[[\"Crm_prp\", \"Litercy\", \"Donatns\", \"Lottery\"]],\n",
-    "    y,\n",
-    "    geometry=gdf.representative_point(),\n",
-    ")"
-   ],
-   "id": "69cb7aca"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Focal predictions\n",
-    "\n",
-    "Focal predicted probabilities are stored in `proba_` \u00e2\u20ac\u201d the probability that the focal observation belongs to the positive class."
-   ],
-   "id": "112d3952"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.proba_"
-   ],
-   "id": "9c024a55"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Binary class predictions (the class with the higher probability) are in `pred_`."
-   ],
-   "id": "ab035a30"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.pred_"
-   ],
-   "id": "f162cd18"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Locations with missing values were not fitted due to extreme class imbalance in their local context (fewer than 20% of local `y` values belong to the minority class). Rather than failing, `gwlearn` skips those locations and records them as not predicted.\n",
-    "\n",
-    "`prediction_rate_` gives the proportion of focal locations that have a fitted local model."
-   ],
-   "id": "db05f12a"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.prediction_rate_"
-   ],
-   "id": "b05e653e"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Focal metrics\n",
-    "\n",
-    "Focal accuracy is computed only over locations that have a prediction."
-   ],
-   "id": "a2378559"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_mask = model.pred_.notna()\n",
-    "metrics.accuracy_score(y[na_mask], model.pred_[na_mask])"
-   ],
-   "id": "61d989d2"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Pooled metrics\n",
-    "\n",
-    "You can also extract all observations from all local models and measure performance on that pooled set. `y_pooled_` and `pred_pooled_` aggregate the weighted training observations across every local model."
-   ],
-   "id": "9557dae8"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "metrics.accuracy_score(model.y_pooled_, model.pred_pooled_)"
-   ],
-   "id": "c62f0736"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Pooled metrics tend to be lower than focal metrics because distance-decay weighting means that observations far from a focal point are still included in pooled data, but fit less well than the focal observation itself.\n",
-    "\n",
-    "You can also compute a metric separately for each local model using `local_metric`."
-   ],
-   "id": "91597688"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "local_accuracy = model.local_metric(metrics.accuracy_score)\n",
-    "local_accuracy"
-   ],
-   "id": "fd594fa4"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "gdf.plot(\n",
-    "    local_accuracy, legend=True, missing_kwds=dict(color=\"lightgray\")\n",
-    ").set_axis_off()"
-   ],
-   "id": "936151a6"
+    "    column=\"SMR\",\n",
+    "    cmap=\"RdYlGn_r\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"SMR (observed/expected deaths)\", \"shrink\": 0.6},\n",
+    "    ax=axes[0],\n",
+    ")\n",
+    "axes[0].set_title(\"Standardised Mortality Ratio (SMR)\")\n",
+    "axes[0].set_axis_off()\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"UNEMP\",\n",
+    "    cmap=\"YlOrRd\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"Unemployment rate (%)\", \"shrink\": 0.6},\n",
+    "    ax=axes[1],\n",
+    ")\n",
+    "axes[1].set_title(\"Unemployment rate\")\n",
+    "axes[1].set_axis_off()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b8c9d0e1",
    "metadata": {},
    "source": [
-    "## Local coefficients\n",
+    "There is visible spatial clustering in both SMR and unemployment, suggesting the relationship between deprivation and mortality may vary across the region.\n",
     "\n",
-    "`local_coef_` contains the locally estimated **log-odds** coefficients \u00e2\u20ac\u201d one column per predictor, one row per location. Skipped locations appear as `NaN`. Mapping these surfaces shows where each predictor's association with the outcome strengthens, weakens, or reverses direction across space."
-   ],
-   "id": "1e33b309"
+    "## 4. Global logistic regression baseline\n",
+    "\n",
+    "Before fitting GWLR, establish a global logistic regression baseline."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c9d0e1f2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.local_coef_"
-   ],
-   "id": "14245d33"
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "X = gdf[[\"OCC_TEC\", \"OWNH\", \"POP65\", \"UNEMP\"]]\n",
+    "y = gdf[\"high_mortality\"]\n",
+    "\n",
+    "glr = LogisticRegression(max_iter=1000).fit(X, y)\n",
+    "global_pred = glr.predict(X)\n",
+    "\n",
+    "print(f\"Global accuracy: {metrics.accuracy_score(y, global_pred):.3f}\")\n",
+    "print(f\"Global F1:       {metrics.f1_score(y, global_pred):.3f}\")\n",
+    "print(\"\\nGlobal coefficients:\")\n",
+    "for name, coef in zip(X.columns, glr.coef_[0], strict=True):\n",
+    "    print(f\"  {name}: {coef:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "## 5. Fit GWLogisticRegression\n",
+    "\n",
+    "With 262 municipalities, an adaptive bandwidth of 80 neighbours gives each local model enough data while still capturing spatial variation."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e1f2a3b4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, axs = plt.subplots(2, 2, figsize=(12, 10))\n",
+    "model = GWLogisticRegression(bandwidth=80, fixed=False, kernel=\"bisquare\")\n",
+    "model.fit(X, y, geometry=gdf.representative_point())\n",
     "\n",
-    "for column, ax in zip(model.local_coef_.columns, axs.flat, strict=False):\n",
+    "print(f\"Prediction rate: {model.prediction_rate_:.3f}\")\n",
+    "print(f\"Global accuracy: {metrics.accuracy_score(y, global_pred):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "## 6. Where does excess mortality cluster?\n",
+    "\n",
+    "Map the focal predictions against the actual high-mortality municipalities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[\"pred\"] = model.pred_\n",
+    "gdf[\"proba\"] = model.proba_[1].values\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 5))\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"high_mortality\",\n",
+    "    cmap=\"RdYlGn_r\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"High mortality (1=yes)\", \"shrink\": 0.6},\n",
+    "    ax=axes[0],\n",
+    ")\n",
+    "axes[0].set_title(\"Observed: high mortality (SMR > 1)\")\n",
+    "axes[0].set_axis_off()\n",
+    "\n",
+    "gdf.plot(\n",
+    "    column=\"proba\",\n",
+    "    cmap=\"RdYlGn_r\",\n",
+    "    legend=True,\n",
+    "    legend_kwds={\"label\": \"P(high mortality)\", \"shrink\": 0.6},\n",
+    "    ax=axes[1],\n",
+    ")\n",
+    "axes[1].set_title(\"GWR predicted probability of high mortality\")\n",
+    "axes[1].set_axis_off()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "source": [
+    "## 7. Spatially varying coefficients\n",
+    "\n",
+    "The local coefficients reveal which socioeconomic factors drive high mortality in different parts of the region. A positive local coefficient means that variable increases the log-odds of excess mortality locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for col in X.columns:\n",
+    "    gdf[f\"coef_{col}\"] = model.local_coef_[col].values\n",
+    "\n",
+    "model.local_coef_.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2, 2, figsize=(14, 10))\n",
+    "axes = axes.flatten()\n",
+    "\n",
+    "for ax, col in zip(axes, X.columns, strict=True):\n",
     "    gdf.plot(\n",
-    "        model.local_coef_[column],\n",
+    "        column=f\"coef_{col}\",\n",
+    "        cmap=\"RdBu_r\",\n",
     "        legend=True,\n",
+    "        legend_kwds={\"label\": \"Local coef.\", \"shrink\": 0.6},\n",
     "        ax=ax,\n",
-    "        missing_kwds=dict(color=\"lightgray\"),\n",
     "    )\n",
-    "    ax.set_title(column)\n",
-    "    ax.set_axis_off()"
-   ],
-   "id": "56416df0"
+    "    ax.set_title(f\"Local coef: {col}\")\n",
+    "    ax.set_axis_off()\n",
+    "\n",
+    "plt.suptitle(\"GWR: Spatially varying predictors of high mortality - Tokyo\", fontsize=13)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e7f8a9b0",
    "metadata": {},
    "source": [
-    "For more on dealing with class imbalance, see the [imbalance guide](./imbalance.ipynb). For details on predicting at new locations, see the [Prediction](./predict.ipynb) guide."
-   ],
-   "id": "3a295f5e"
+    "The coefficient maps reveal clear spatial heterogeneity:\n",
+    "\n",
+    "- **`UNEMP`** has a strong positive effect (higher unemployment → higher mortality risk) in some areas but a weaker or negligible effect in others, suggesting unemployment is not a universal driver of excess mortality across the region.\n",
+    "- **`OWNH`** (home ownership) tends to be protective (negative coefficient) in the urban core but less so in outer municipalities.\n",
+    "- **`POP65`** and **`OCC_TEC`** also show spatially varying effects, reflecting the heterogeneous urban fabric of the Greater Tokyo region.\n",
+    "\n",
+    "These patterns are invisible in the global logistic regression, which forces a single coefficient for each predictor.\n",
+    "\n",
+    "## 8. Pooled metrics\n",
+    "\n",
+    "Use the pooled predictions to compute overall classification performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(metrics.classification_report(model.y_pooled_, model.pred_pooled_))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "source": [
+    "## 9. Summary\n",
+    "\n",
+    "This example used `GWLogisticRegression` to investigate spatial variation in the socioeconomic drivers of excess mortality across Tokyo:\n",
+    "\n",
+    "- The **global logistic regression** identifies average relationships between deprivation indicators and high mortality risk across all 262 municipalities.\n",
+    "- **GWLR** reveals these relationships are spatially non-stationary - unemployment, home ownership, and elderly population share all have locally varying effects depending on where in the region a municipality sits.\n",
+    "- `local_coef_` maps the spatially varying log-odds coefficients, `proba_` gives the local predicted probability of excess mortality, and `pred_pooled_` enables pooled performance evaluation.\n",
+    "\n",
+    "For guidance on handling class imbalance in geographically weighted classification, see [class imbalance](./imbalance.ipynb). For bandwidth selection, see [bandwidth search](./bandwidth_search.ipynb)."
+   ]
   }
  ],
  "metadata": {
@@ -283,7 +323,9 @@
   "language_info": {
    "name": "python",
    "version": "3.11.0"
-  }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,6 +12,8 @@ installation
 :caption: User Guide
 introduction
 linear
+gw_linear_regression_example
+gw_logistic_regression_example
 ensemble
 predict
 imbalance


### PR DESCRIPTION
## Summary
Closes #85

This PR adds two new example notebooks to the User Guide demonstrating complete workflows for `GWLinearRegression` and `GWLogisticRegression`.

## Changes
- `docs/source/gw_linear_regression_example.ipynb` - new example notebook
- `docs/source/gw_logistic_regression_example.ipynb` - new example notebook
- `docs/source/index.md` - added both notebooks to the User Guide toctree

## What the examples cover
**GWLinearRegression example:**
- Real-world dataset: US per-capita income by state, 1929-2009 (`libpysal` `us_income`)
- Research question: does the income convergence effect vary spatially across US states?
- Global OLS baseline for comparison
- Spatially varying coefficients (`local_coef_`) mapped and interpreted by region
- Local R² (`local_r2_`) and residual (`resid_`) analysis

**GWLogisticRegression example:**
- Creating a binary target from a continuous variable
- Fitting the model and checking `prediction_rate_`
- Focal accuracy and pooled metrics (`y_pooled_`, `pred_pooled_`)
- Per-model metrics via `local_metric`
- Mapping local log-odds coefficients (`local_coef_`)