### PR TITLE
ENH: expose local_metric on regressors as well

### DIFF
--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -618,6 +618,23 @@ class _BaseModel(BaseEstimator):
                 results.append(func(y, y_pred, *args, **kwargs))
         return np.array(results)
 
+    def _maybe_set_local_metric_data(self) -> None:
+        """Populate local metric arrays when _score_data stores y/pred pairs."""
+        if not hasattr(self, "_score_data") or len(self._score_data) == 0:
+            return
+
+        first = self._score_data[0]
+        if not (
+            isinstance(first, tuple | list)
+            and len(first) >= 2
+            and hasattr(first[0], "shape")
+            and hasattr(first[1], "shape")
+        ):
+            return
+
+        self._y_local = [x[0] for x in self._score_data]
+        self._pred_local = [x[1] for x in self._score_data]
+
 
 class BaseClassifier(ClassifierMixin, _BaseModel):
     """Generic geographically weighted classification meta-estimator.
@@ -968,8 +985,7 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
 
         self._n_fitted_models = (~self.proba_[col].isna()).sum()
         self.prediction_rate_ = self._n_fitted_models / nan_mask.shape[0]
-        self._y_local = [x[0] for x in self._score_data]
-        self._pred_local = [x[1] for x in self._score_data]
+        self._maybe_set_local_metric_data()
 
         if self.leave_out and self.prediction_rate_ > 0:
             self.left_out_y_ = np.concatenate([arr[1] for arr in left_out_proba])
@@ -1665,8 +1681,7 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         self.TSS_ = pd.Series(tss, index=self._names)
         self.y_bar_ = pd.Series(y_bar, index=self._names)
         self.local_r2_ = (self.TSS_ - self.RSS_) / self.TSS_
-        self._y_local = [x[0] for x in self._score_data]
-        self._pred_local = [x[1] for x in self._score_data]
+        self._maybe_set_local_metric_data()
 
         if self.fit_global_model:
             self._fit_global_model(X, y)

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Hashable
 from numbers import Integral, Real
 from pathlib import Path
 from time import time
-from typing import Any, Literal
+from typing import Literal
 
 import geopandas as gpd
 import numpy as np
@@ -592,7 +592,7 @@ class _BaseModel(BaseEstimator):
         local_model: BaseEstimator,  # noqa: ARG002
         X: pd.DataFrame,  # noqa: ARG002
         y: pd.Series,  # noqa: ARG002
-    ) -> object:
+    ) -> float | tuple:
         """Subclasses should implement custom function"""
         return np.nan
 
@@ -617,32 +617,6 @@ class _BaseModel(BaseEstimator):
             else:
                 results.append(func(y, y_pred, *args, **kwargs))
         return np.array(results)
-
-    def _maybe_set_local_metric_data(self) -> None:
-        """Populate local metric arrays when _score_data stores y/pred pairs."""
-        score_data = getattr(self, "_score_data", None)
-        if not isinstance(score_data, tuple) or len(score_data) == 0:
-            return
-
-        y_local: list[np.ndarray] = []
-        pred_local: list[np.ndarray] = []
-
-        for item in score_data:
-            if not isinstance(item, tuple | list) or len(item) < 2:
-                return
-
-            y_item: Any = item[0]
-            pred_item: Any = item[1]
-            if not isinstance(y_item, np.ndarray) or not isinstance(
-                pred_item, np.ndarray
-            ):
-                return
-
-            y_local.append(y_item)
-            pred_local.append(pred_item)
-
-        self._y_local = y_local
-        self._pred_local = pred_local
 
 
 class BaseClassifier(ClassifierMixin, _BaseModel):
@@ -994,7 +968,8 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
 
         self._n_fitted_models = (~self.proba_[col].isna()).sum()
         self.prediction_rate_ = self._n_fitted_models / nan_mask.shape[0]
-        self._maybe_set_local_metric_data()
+        self._y_local = [x[0] for x in self._score_data]
+        self._pred_local = [x[1] for x in self._score_data]
 
         if self.leave_out and self.prediction_rate_ > 0:
             self.left_out_y_ = np.concatenate([arr[1] for arr in left_out_proba])
@@ -1023,7 +998,7 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         local_model: BaseEstimator,
         X: pd.DataFrame,
         y: pd.Series,
-    ) -> object:
+    ) -> tuple:
         return y.to_numpy(), local_model.predict(X)
 
     def _fit_local(
@@ -1690,7 +1665,8 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         self.TSS_ = pd.Series(tss, index=self._names)
         self.y_bar_ = pd.Series(y_bar, index=self._names)
         self.local_r2_ = (self.TSS_ - self.RSS_) / self.TSS_
-        self._maybe_set_local_metric_data()
+        self._y_local = [x[0] for x in self._score_data]
+        self._pred_local = [x[1] for x in self._score_data]
 
         if self.fit_global_model:
             self._fit_global_model(X, y)
@@ -1709,7 +1685,7 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         local_model: BaseEstimator,
         X: pd.DataFrame,
         y: pd.Series,
-    ) -> object:
+    ) -> tuple:
         return y.to_numpy(), local_model.predict(X)
 
     def predict(

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -596,6 +596,28 @@ class _BaseModel(BaseEstimator):
         """Subclasses should implement custom function"""
         return np.nan
 
+    def local_metric(self, func: Callable, *args, **kwargs) -> np.ndarray:
+        """Compute a metric per fitted local model.
+
+        Parameters
+        ----------
+        func : callable
+            Callable with a signature ``func(y_true, y_pred, *args, **kwargs)``.
+
+        Returns
+        -------
+        numpy.ndarray
+            One value per focal location (NaN for skipped / unfitted local models).
+        """
+        results = []
+
+        for y, y_pred in zip(self._y_local, self._pred_local, strict=True):
+            if y.shape[0] == 0:
+                results.append(np.nan)
+            else:
+                results.append(func(y, y_pred, *args, **kwargs))
+        return np.array(results)
+
 
 class BaseClassifier(ClassifierMixin, _BaseModel):
     """Generic geographically weighted classification meta-estimator.
@@ -823,7 +845,7 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         self.undersample = undersample
         self.random_state = random_state
         self.leave_out = leave_out
-        self._empty_score_data = None
+        self._empty_score_data = (np.array([]), np.array([]))
         self._empty_feature_imp = None
 
     def fit(
@@ -946,6 +968,8 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
 
         self._n_fitted_models = (~self.proba_[col].isna()).sum()
         self.prediction_rate_ = self._n_fitted_models / nan_mask.shape[0]
+        self._y_local = [x[0] for x in self._score_data]
+        self._pred_local = [x[1] for x in self._score_data]
 
         if self.leave_out and self.prediction_rate_ > 0:
             self.left_out_y_ = np.concatenate([arr[1] for arr in left_out_proba])
@@ -968,6 +992,14 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
             self._compute_information_criteria()
 
         return self
+
+    def _get_score_data(
+        self,
+        local_model: BaseEstimator,
+        X: pd.DataFrame,
+        y: pd.Series,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return y.to_numpy(), local_model.predict(X)
 
     def _fit_local(
         self,
@@ -1364,28 +1396,6 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
             return float("nan")
         return (y_pred[mask] == y[mask]).mean()
 
-    def local_metric(self, func: Callable, *args, **kwargs) -> np.ndarray:
-        """Compute a metric per fitted local model.
-
-        Parameters
-        ----------
-        func : callable
-            Callable with a signature ``func(y_true, y_pred, *args, **kwargs)``.
-
-        Returns
-        -------
-        numpy.ndarray
-            One value per focal location (NaN for skipped / unfitted local models).
-        """
-        results = []
-
-        for y, y_pred in zip(self._y_local, self._pred_local, strict=True):
-            if y.shape[0] == 0:
-                results.append(np.nan)
-            else:
-                results.append(func(y, y_pred, *args, **kwargs))
-        return np.array(results)
-
 
 class BaseRegressor(_BaseModel, RegressorMixin):
     """Generic geographically weighted regression meta-estimator.
@@ -1574,6 +1584,7 @@ class BaseRegressor(_BaseModel, RegressorMixin):
             **kwargs,
         )
         self.random_state = random_state
+        self._empty_score_data = (np.array([]), np.array([]))
 
     def fit(
         self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None
@@ -1654,6 +1665,8 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         self.TSS_ = pd.Series(tss, index=self._names)
         self.y_bar_ = pd.Series(y_bar, index=self._names)
         self.local_r2_ = (self.TSS_ - self.RSS_) / self.TSS_
+        self._y_local = [x[0] for x in self._score_data]
+        self._pred_local = [x[1] for x in self._score_data]
 
         if self.fit_global_model:
             self._fit_global_model(X, y)
@@ -1666,6 +1679,14 @@ class BaseRegressor(_BaseModel, RegressorMixin):
             self._compute_information_criteria()
 
         return self
+
+    def _get_score_data(
+        self,
+        local_model: BaseEstimator,
+        X: pd.DataFrame,
+        y: pd.Series,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return y.to_numpy(), local_model.predict(X)
 
     def predict(
         self,

--- a/gwlearn/base.py
+++ b/gwlearn/base.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Hashable
 from numbers import Integral, Real
 from pathlib import Path
 from time import time
-from typing import Literal
+from typing import Any, Literal
 
 import geopandas as gpd
 import numpy as np
@@ -592,7 +592,7 @@ class _BaseModel(BaseEstimator):
         local_model: BaseEstimator,  # noqa: ARG002
         X: pd.DataFrame,  # noqa: ARG002
         y: pd.Series,  # noqa: ARG002
-    ) -> float | tuple:
+    ) -> object:
         """Subclasses should implement custom function"""
         return np.nan
 
@@ -620,20 +620,29 @@ class _BaseModel(BaseEstimator):
 
     def _maybe_set_local_metric_data(self) -> None:
         """Populate local metric arrays when _score_data stores y/pred pairs."""
-        if not hasattr(self, "_score_data") or len(self._score_data) == 0:
+        score_data = getattr(self, "_score_data", None)
+        if not isinstance(score_data, tuple) or len(score_data) == 0:
             return
 
-        first = self._score_data[0]
-        if not (
-            isinstance(first, tuple | list)
-            and len(first) >= 2
-            and hasattr(first[0], "shape")
-            and hasattr(first[1], "shape")
-        ):
-            return
+        y_local: list[np.ndarray] = []
+        pred_local: list[np.ndarray] = []
 
-        self._y_local = [x[0] for x in self._score_data]
-        self._pred_local = [x[1] for x in self._score_data]
+        for item in score_data:
+            if not isinstance(item, tuple | list) or len(item) < 2:
+                return
+
+            y_item: Any = item[0]
+            pred_item: Any = item[1]
+            if not isinstance(y_item, np.ndarray) or not isinstance(
+                pred_item, np.ndarray
+            ):
+                return
+
+            y_local.append(y_item)
+            pred_local.append(pred_item)
+
+        self._y_local = y_local
+        self._pred_local = pred_local
 
 
 class BaseClassifier(ClassifierMixin, _BaseModel):
@@ -1014,7 +1023,7 @@ class BaseClassifier(ClassifierMixin, _BaseModel):
         local_model: BaseEstimator,
         X: pd.DataFrame,
         y: pd.Series,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> object:
         return y.to_numpy(), local_model.predict(X)
 
     def _fit_local(
@@ -1700,7 +1709,7 @@ class BaseRegressor(_BaseModel, RegressorMixin):
         local_model: BaseEstimator,
         X: pd.DataFrame,
         y: pd.Series,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> object:
         return y.to_numpy(), local_model.predict(X)
 
     def predict(

--- a/gwlearn/ensemble.py
+++ b/gwlearn/ensemble.py
@@ -298,7 +298,7 @@ class GWRandomForestClassifier(BaseClassifier):
         local_model: BaseEstimator,
         X: pd.DataFrame,  # noqa: ARG002
         y: pd.Series,  # noqa: ARG002
-    ) -> float:
+    ) -> tuple:
         return local_model.oob_score_
 
 
@@ -484,7 +484,6 @@ class GWGradientBoostingClassifier(BaseClassifier):
         )
 
         self._model_type = "gradient_boosting"
-        self._empty_score_data = np.nan
 
     def fit(
         self, X: pd.DataFrame, y: pd.Series, geometry: gpd.GeoSeries | None = None
@@ -778,7 +777,7 @@ class GWRandomForestRegressor(BaseRegressor):
         local_model: BaseEstimator,
         X: pd.DataFrame,  # noqa: ARG002
         y: pd.Series,  # noqa: ARG002
-    ) -> float:
+    ) -> tuple:
         return local_model.oob_score_
 
 

--- a/gwlearn/tests/test_base.py
+++ b/gwlearn/tests/test_base.py
@@ -14,6 +14,7 @@ from packaging.version import Version
 from shapely.geometry import Point
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.metrics import accuracy_score, mean_absolute_error
 from sklearn.model_selection import GridSearchCV
 
 from gwlearn.base import BaseClassifier, BaseRegressor, _kernel_functions
@@ -1949,6 +1950,32 @@ def test_classifier_score(sample_data):
     assert isinstance(acc, float)
 
 
+def test_classifier_local_metric(sample_data):
+    """Test local_metric on BaseClassifier."""
+    X, y, geometry = sample_data
+    clf = BaseClassifier(
+        LogisticRegression,
+        bandwidth=10,
+        fixed=False,
+        random_state=42,
+        max_iter=200,
+        strict=False,
+        n_jobs=1,
+    )
+    clf.fit(X, y, geometry)
+
+    local_accuracy = clf.local_metric(accuracy_score)
+    expected = np.array(
+        [
+            np.nan if y_local.shape[0] == 0 else accuracy_score(y_local, pred_local)
+            for y_local, pred_local in zip(clf._y_local, clf._pred_local, strict=True)
+        ]
+    )
+
+    np.testing.assert_allclose(local_accuracy, expected, equal_nan=True)
+    assert len(local_accuracy) == len(X)
+
+
 def test_regressor_score(sample_regression_data):
     """Test the score method of BaseRegressor with geometry argument."""
     X, y, geometry = sample_regression_data
@@ -1964,6 +1991,32 @@ def test_regressor_score(sample_regression_data):
     r2 = reg.score(X, y, geometry)
     assert -1.0 <= r2 <= 1.0
     assert isinstance(r2, float)
+
+
+def test_regressor_local_metric(sample_regression_data):
+    """Test local_metric on BaseRegressor."""
+    X, y, geometry = sample_regression_data
+    reg = BaseRegressor(
+        LinearRegression,
+        bandwidth=10,
+        fixed=False,
+        random_state=42,
+        n_jobs=1,
+    )
+    reg.fit(X, y, geometry)
+
+    local_mae = reg.local_metric(mean_absolute_error)
+    expected = np.array(
+        [
+            np.nan
+            if y_local.shape[0] == 0
+            else mean_absolute_error(y_local, pred_local)
+            for y_local, pred_local in zip(reg._y_local, reg._pred_local, strict=True)
+        ]
+    )
+
+    np.testing.assert_allclose(local_mae, expected, equal_nan=True)
+    assert len(local_mae) == len(X)
 
 
 def test_metadata_routing(sample_regression_data):


### PR DESCRIPTION
I realised that the `local_metric` method was exposed only on classifiers. Fixing that now and making sure that bare base models can use it as well as we were populating it only from within the subclasses.