### PR TITLE
TST: ignore warnings about OOB scores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,5 +123,6 @@ filterwarnings = [
     "error",
     "ignore:The 'shapely.geos' module is deprecated*:DeprecationWarning",
     "ignore:This process \\(pid=\\d+\\) is multi-threaded*:DeprecationWarning",
-    "ignore:divide by zero encountered in power:RuntimeWarning"
+    "ignore:divide by zero encountered in power:RuntimeWarning",
+    "ignore:Some inputs do not have OOB scores.",
 ]


### PR DESCRIPTION
It is fine to have these propagating to users as it indicates the bandwidth might be too small to reliably retrieve OOB scores. Ignoring within the test suite to avoid current failures on dev (we fail on warnings here).