### PR TITLE
TST: ignore deprecation warning solved by joblib in upstream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,4 +89,5 @@ filterwarnings = [
     "ignore:This process \\(pid=\\d+\\) is multi-threaded*:DeprecationWarning",
     "ignore:divide by zero encountered in power:RuntimeWarning",
     "ignore:Some inputs do not have OOB scores.",
+    "ignore:Setting the shape on a NumPy array"
 ]


### PR DESCRIPTION
Should resolve fialing CI. Note that pytest is set to fail on warning. The issue comes from joblib and is resolved on joblib main.