### PR TITLE
fix: missing libjxl dependency in docs build

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -13,6 +13,7 @@ dependencies:
   # testing
   - geodatasets
   - mgwr
+  - libjxl=0.11
   # docs
   - pandarm
   - ipykernel

--- a/spml/ensemble.py
+++ b/spml/ensemble.py
@@ -19,7 +19,7 @@ from .base import BaseClassifier, BaseRegressor
 
 
 class GWRandomForestClassifier(BaseClassifier):
-    """Geographically weighted random forest classifier.
+    """Geographically weighted random forest classifiers.
 
     Fits one :class:`sklearn.ensemble.RandomForestClassifier` per focal observation
     using spatially varying sample weights.

--- a/spml/ensemble.py
+++ b/spml/ensemble.py
@@ -19,7 +19,7 @@ from .base import BaseClassifier, BaseRegressor
 
 
 class GWRandomForestClassifier(BaseClassifier):
-    """Geographically weighted random forest classifiers.
+    """Geographically weighted random forest classifier.
 
     Fits one :class:`sklearn.ensemble.RandomForestClassifier` per focal observation
     using spatially varying sample weights.


### PR DESCRIPTION
<img width="912" height="362" alt="image" src="https://github.com/user-attachments/assets/732e616f-8f6e-46f0-a516-996413bb2165" />

pyogrio looks for libjxl.so.0.11 which isn't there (i tried using libjxl=0.13, that didn't work)
this pr adds that dependency in tests